### PR TITLE
Ability to transform actions/state similar to fcomb/redux-logger

### DIFF
--- a/src/LogMonitor.js
+++ b/src/LogMonitor.js
@@ -48,6 +48,7 @@ export default class LogMonitor extends Component {
     actionsById: PropTypes.object,
     stagedActionIds: PropTypes.array,
     skippedActionIds: PropTypes.array,
+    actionTransformer: PropTypes.func,
     monitorState: PropTypes.shape({
       initialScrollTop: PropTypes.number
     }),
@@ -62,6 +63,7 @@ export default class LogMonitor extends Component {
 
   static defaultProps = {
     select: (state) => state,
+    actionTransformer: (action) => action,
     theme: 'nicinabox',
     preserveScrollTop: true
   };
@@ -163,11 +165,12 @@ export default class LogMonitor extends Component {
   render() {
     const elements = [];
     const theme = this.getTheme();
-    const { actionsById, skippedActionIds, stagedActionIds, computedStates, select } = this.props;
+    const { actionTransformer, actionsById, skippedActionIds, stagedActionIds, computedStates, select } = this.props;
 
     for (let i = 0; i < stagedActionIds.length; i++) {
       const actionId = stagedActionIds[i];
       const action = actionsById[actionId].action;
+      const transformedAction = actionTransformer(action);
       const { state, error } = computedStates[i];
       let previousState;
       if (i > 0) {
@@ -177,7 +180,7 @@ export default class LogMonitor extends Component {
         <LogMonitorEntry key={actionId}
                          theme={theme}
                          select={select}
-                         action={action}
+                         action={transformedAction}
                          actionId={actionId}
                          state={state}
                          previousState={previousState}

--- a/src/LogMonitor.js
+++ b/src/LogMonitor.js
@@ -49,6 +49,7 @@ export default class LogMonitor extends Component {
     stagedActionIds: PropTypes.array,
     skippedActionIds: PropTypes.array,
     actionTransformer: PropTypes.func,
+    stateTransformer: PropTypes.func,
     monitorState: PropTypes.shape({
       initialScrollTop: PropTypes.number
     }),
@@ -64,6 +65,7 @@ export default class LogMonitor extends Component {
   static defaultProps = {
     select: (state) => state,
     actionTransformer: (action) => action,
+    stateTransformer: (state) => state,
     theme: 'nicinabox',
     preserveScrollTop: true
   };
@@ -165,22 +167,23 @@ export default class LogMonitor extends Component {
   render() {
     const elements = [];
     const theme = this.getTheme();
-    const { actionTransformer, actionsById, skippedActionIds, stagedActionIds, computedStates, select } = this.props;
+    const { stateTransformer, actionTransformer, actionsById,
+      skippedActionIds, stagedActionIds, computedStates, select } = this.props;
 
     for (let i = 0; i < stagedActionIds.length; i++) {
       const actionId = stagedActionIds[i];
-      const action = actionsById[actionId].action;
-      const transformedAction = actionTransformer(action);
-      const { state, error } = computedStates[i];
+      let action = actionTransformer(actionsById[actionId].action);
+      let state = stateTransformer(computedStates[i].state);
+      let error = computedStates[i].error;
       let previousState;
       if (i > 0) {
-        previousState = computedStates[i - 1].state;
+        previousState = stateTransformer(computedStates[i - 1].state);
       }
       elements.push(
         <LogMonitorEntry key={actionId}
                          theme={theme}
                          select={select}
-                         action={transformedAction}
+                         action={action}
                          actionId={actionId}
                          state={state}
                          previousState={previousState}


### PR DESCRIPTION
When using Symbols as action types, LogMonitor can't show the type anymore.  I get around this in `redux-logger` using their `actionTransformer` parameter.  This PR implements the same transform api here for actions/state.

I'm not sure if mutations to the actions / computedState are allowed or not.