### PR TITLE
Add expandActionRoot/expandStateRoot props

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Name                  | Description
 `theme`               | Either a string referring to one of the themes provided by [redux-devtools-themes](https://github.com/gaearon/redux-devtools-themes) (feel free to contribute!) or a custom object of the same format. Optional. By default, set to [`'nicinabox'`](https://github.com/gaearon/redux-devtools-themes/blob/master/src/nicinabox.js).
 `select`              | A function that selects the slice of the state for DevTools to show. For example, `state => state.thePart.iCare.about`. Optional. By default, set to `state => state`.
 `preserveScrollTop`   | When `true`, records the current scroll top every second so it can be restored on refresh. This only has effect when used together with `persistState()` enhancer from Redux DevTools. By default, set to `true`.
+`expandActionRoot`    | A boolean, if `true`, action root key of JSON tree in DevTools is expanded, otherwise collapsed. By default, set to `true`.
+`expandStateRoot`     | A boolean, if `true`, state root key of JSON tree in DevTools is expanded, otherwise collapsed. By default, set to `true`.
 
 ### License
 

--- a/src/LogMonitor.js
+++ b/src/LogMonitor.js
@@ -57,13 +57,17 @@ export default class LogMonitor extends Component {
     theme: PropTypes.oneOfType([
       PropTypes.object,
       PropTypes.string
-    ])
+    ]),
+    expandActionRoot: PropTypes.bool,
+    expandStateRoot: PropTypes.bool
   };
 
   static defaultProps = {
     select: (state) => state,
     theme: 'nicinabox',
-    preserveScrollTop: true
+    preserveScrollTop: true,
+    expandActionRoot: true,
+    expandStateRoot: true
   };
 
   shouldComponentUpdate = shouldPureComponentUpdate;
@@ -183,6 +187,8 @@ export default class LogMonitor extends Component {
                          previousState={previousState}
                          collapsed={skippedActionIds.indexOf(actionId) > -1}
                          error={error}
+                         expandActionRoot={this.props.expandActionRoot}
+                         expandStateRoot={this.props.expandStateRoot}
                          onActionClick={this.handleToggleAction} />
       );
     }

--- a/src/LogMonitorEntry.js
+++ b/src/LogMonitorEntry.js
@@ -21,7 +21,9 @@ export default class LogMonitorEntry extends Component {
     select: PropTypes.func.isRequired,
     error: PropTypes.string,
     onActionClick: PropTypes.func.isRequired,
-    collapsed: PropTypes.bool
+    collapsed: PropTypes.bool,
+    expandActionRoot: PropTypes.bool,
+    expandStateRoot: PropTypes.bool
   };
 
   shouldComponentUpdate = shouldPureComponentUpdate;
@@ -41,6 +43,7 @@ export default class LogMonitorEntry extends Component {
             keyName={'state'}
             data={this.props.select(state)}
             previousData={this.props.select(this.props.previousState)}
+            expandRoot={this.props.expandStateRoot}
             style={styles.tree} />
         );
       } catch (err) {
@@ -84,6 +87,7 @@ export default class LogMonitorEntry extends Component {
           theme={this.props.theme}
           collapsed={collapsed}
           action={action}
+          expandActionRoot={this.props.expandActionRoot}
           onClick={this.handleActionClick}
           style={{...styles.entry, ...styleEntry}}/>
         {!collapsed &&

--- a/src/LogMonitorEntryAction.js
+++ b/src/LogMonitorEntryAction.js
@@ -20,7 +20,11 @@ export default class LogMonitorAction extends React.Component {
         ...styles.payload,
         backgroundColor: this.props.theme.base00
       }}>
-        { Object.keys(payload).length > 0 ? <JSONTree theme={this.props.theme} keyName={'action'} data={payload}/> : '' }
+        { Object.keys(payload).length > 0 ?
+          <JSONTree theme={this.props.theme}
+                    keyName={'action'}
+                    data={payload}
+                    expandRoot={this.props.expandActionRoot} /> : '' }
       </div>
     );
   }


### PR DESCRIPTION
As mentioned in #9, it would be nice to have ability to set action/state roots in JSON tree to collapsed/not expanded via props.

**react-json-tree** takes additional `expandRoot` prop from v0.3.0, so this is fairly easy.

I added two new props to **LogMonitor**, `expandActionRoot` and `expandStateRoot` that are set to `true` by default, but can be explicitly set to `false`.

Since `collapsed` prop name was already taken and refers to **LogMonitorEntry**, I decided to name them similar to **react-json-tree** prop name. I think they are less ambiguous.