### PR TITLE
fix: add babel-plugin-add-module-exports for default export

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "plugins": ["transform-react-jsx"],
+  "plugins": ["transform-react-jsx", "add-module-exports"],
   "presets": ["es2015", "stage-0"]
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-core": "^6.1.2",
     "babel-eslint": "^4.1.4",
     "babel-loader": "^6.0.1",
+    "babel-plugin-add-module-exports": "^0.1.1",
     "babel-plugin-transform-react-jsx": "^6.0.18",
     "babel-preset-es2015": "^6.1.2",
     "babel-preset-stage-0": "^6.1.2",


### PR DESCRIPTION
[upgrading to Babel 6](https://github.com/gaearon/redux-devtools-log-monitor/pull/10) silently broke everyone using `redux-devtools-log-monitor` with CommonJS `require` and `module.exports` due to [Kill CommonJS default export behaviour - babel/babel#2212](https://phabricator.babeljs.io/T2212). this fixes that unintended breaking change.

repeat of https://github.com/gaearon/redux-thunk/pull/41