### PR TITLE
Call toString on action type before displaying

### DIFF
--- a/src/LogMonitorEntryAction.js
+++ b/src/LogMonitorEntryAction.js
@@ -39,7 +39,7 @@ export default class LogMonitorAction extends Component {
       }}>
         <div style={styles.actionBar}
           onClick={this.props.onClick}>
-          {type}
+          {type.toString()}
         </div>
         {!this.props.collapsed ? this.renderPayload(payload) : ''}
       </div>


### PR DESCRIPTION
I like to use Symbols as action types in Redux, but currently these will not show up in the log monitor. This PR contains the most straightforward way of solving this, which is to call `toString` on the action type.