### PR TITLE
[issue #45] - Performance optimizations, reduced wasted renders

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "redux-devtools": "^3.0.0"
   },
   "dependencies": {
+    "lodash.debounce": "^4.0.4",
     "react-json-tree": "^0.6.5",
     "react-pure-render": "^1.0.2",
     "redux-devtools-themes": "^1.0.0"

--- a/src/LogMonitor.js
+++ b/src/LogMonitor.js
@@ -124,7 +124,7 @@ export default class LogMonitor extends Component {
   componentWillUnmount() {
     const node = this.refs.container;
     if (node && this.props.preserveScrollTop) {
-      node.addEventListener('scroll', this.updateScrollTop);
+      node.removeEventListener('scroll', this.updateScrollTop);
     }
   }
 

--- a/src/LogMonitor.js
+++ b/src/LogMonitor.js
@@ -6,6 +6,7 @@ import { ActionCreators } from 'redux-devtools';
 import { updateScrollTop } from './actions';
 import reducer from './reducers';
 import LogMonitorEntryList from './LogMonitorEntryList';
+import debounce from 'lodash.debounce';
 
 const { reset, rollback, commit, sweep, toggleAction } = ActionCreators;
 
@@ -37,14 +38,6 @@ const styles = {
     overflowX: 'hidden',
     overflowY: 'auto'
   }
-};
-
-const debounced = (func, wait) => {
-  let timeout;
-  return () => {
-    clearTimeout(timeout);
-    timeout = setTimeout(func, wait);
-  };
 };
 
 export default class LogMonitor extends Component {
@@ -80,7 +73,7 @@ export default class LogMonitor extends Component {
 
   shouldComponentUpdate = shouldPureComponentUpdate;
 
-  updateScrollTop = debounced(() => {
+  updateScrollTop = debounce(() => {
     const node = this.refs.container;
     this.props.dispatch(updateScrollTop(node ? node.scrollTop : 0));
   }, 500);

--- a/src/LogMonitorEntryList.js
+++ b/src/LogMonitorEntryList.js
@@ -1,0 +1,67 @@
+import React, { PropTypes, Component } from 'react';
+import LogMonitorEntry from './LogMonitorEntry';
+import shouldPureComponentUpdate from 'react-pure-render/function';
+
+export default class LogMonitorEntryList extends Component {
+
+  static propTypes = {
+    actionsById: PropTypes.object,
+    computedStates: PropTypes.array,
+    stagedActionIds: PropTypes.array,
+    skippedActionIds: PropTypes.array,
+
+    select: PropTypes.func.isRequired,
+    onActionClick: PropTypes.func.isRequired,
+    theme: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.string
+    ]),
+    expandActionRoot: PropTypes.bool,
+    expandStateRoot: PropTypes.bool
+  };
+
+  shouldComponentUpdate = shouldPureComponentUpdate;
+
+  render() {
+    const elements = [];
+    const {
+      theme,
+      actionsById,
+      computedStates,
+      select,
+      skippedActionIds,
+      stagedActionIds,
+      expandActionRoot,
+      expandStateRoot,
+      onActionClick
+      } = this.props;
+
+    for (let i = 0; i < stagedActionIds.length; i++) {
+      const actionId = stagedActionIds[i];
+      const action = actionsById[actionId].action;
+      const { state, error } = computedStates[i];
+      let previousState;
+      if (i > 0) {
+        previousState = computedStates[i - 1].state;
+      }
+      elements.push(
+        <LogMonitorEntry key={actionId}
+          theme={theme}
+          select={select}
+          action={action}
+          actionId={actionId}
+          state={state}
+          previousState={previousState}
+          collapsed={skippedActionIds.indexOf(actionId) > -1}
+          error={error}
+          expandActionRoot={expandActionRoot}
+          expandStateRoot={expandStateRoot}
+          onActionClick={onActionClick} />
+      );
+    }
+
+    return (<div>
+      {elements}
+    </div>);
+  }
+}


### PR DESCRIPTION
Related issue https://github.com/gaearon/redux-devtools-log-monitor/issues/45.

**What's done:**
- Decomposed LogMonitor, created LogMonitorEntryList, so log array is recalculated only when props are updated
- Added debounced scroll listener to container, so scrollTop is updated only when scroll ends

Test case I was performing: 
- add new item to a list of 300+ actions. 

Here are the `Perf.printWasted()` results:

**Before:**
![](https://api.monosnap.com/rpc/file/download?id=QBvPM7l2X9fi4uAosi41ekVxNUiUOM)

**After:**
![](https://api.monosnap.com/rpc/file/download?id=RyJzbnmm0EuJt1SM0WHOay2EquYrWt)

So, I think wasted renders should be fixed within this pull request. 

As for inlined styles that cause long [compsite layout and rendering operations](https://api.monosnap.com/rpc/file/download?id=G0EeJqPacIstwkAvFhkjWCOcydr7CC), it will require more complex solution like make inlined styles shared in `react-json-tree`. That should improve rendering performance. 
I might take a look into that next week.

@gaearon, please review and thanks for providing such a nice opportunity to contribute.