### PR TITLE
Add density props

### DIFF
--- a/src/LogMonitor.js
+++ b/src/LogMonitor.js
@@ -48,6 +48,9 @@ export default class LogMonitor extends Component {
     actionsById: PropTypes.object,
     stagedActionIds: PropTypes.array,
     skippedActionIds: PropTypes.array,
+    density: PropTypes.oneOf(['comfortable',
+      'cozy',
+      'compact']),
     monitorState: PropTypes.shape({
       initialScrollTop: PropTypes.number
     }),
@@ -197,6 +200,7 @@ export default class LogMonitor extends Component {
                          state={state}
                          previousState={previousState}
                          collapsed={skippedActionIds.indexOf(actionId) > -1}
+                         density={this.props.density}
                          error={error}
                          expandActionRoot={this.props.expandActionRoot}
                          expandStateRoot={this.props.expandStateRoot}

--- a/src/LogMonitorEntry.js
+++ b/src/LogMonitorEntry.js
@@ -19,6 +19,9 @@ export default class LogMonitorEntry extends Component {
     action: PropTypes.object.isRequired,
     actionId: PropTypes.number.isRequired,
     select: PropTypes.func.isRequired,
+    density: PropTypes.oneOf(['comfortable',
+      'cozy',
+      'compact']),
     error: PropTypes.string,
     onActionClick: PropTypes.func.isRequired,
     collapsed: PropTypes.bool,
@@ -31,6 +34,15 @@ export default class LogMonitorEntry extends Component {
   constructor(props) {
     super(props);
     this.handleActionClick = this.handleActionClick.bind(this);
+  }
+
+  addDensity(style) {
+    const { density } = this.props
+    switch(density) {
+      case 'compact':
+        style.marginTop = 0
+    }
+    return style
   }
 
   printState(state, error) {
@@ -48,7 +60,7 @@ export default class LogMonitorEntry extends Component {
                 undefined
             }
             expandRoot={this.props.expandStateRoot}
-            style={styles.tree} />
+            style={this.addDensity(styles.tree)} />
         );
       } catch (err) {
         errorText = 'Error selecting state.';
@@ -93,6 +105,7 @@ export default class LogMonitorEntry extends Component {
           action={action}
           expandActionRoot={this.props.expandActionRoot}
           onClick={this.handleActionClick}
+          density={this.props.density}
           style={{...styles.entry, ...styleEntry}}/>
         {!collapsed &&
           <div>

--- a/src/LogMonitorEntryAction.js
+++ b/src/LogMonitorEntryAction.js
@@ -10,10 +10,33 @@ const styles = {
   payload: {
     margin: 0,
     overflow: 'auto'
-  }
+  },
+  tree: {}
 };
 
 export default class LogMonitorAction extends Component {
+
+  addDensity(style) {
+    const { density } = this.props
+    switch(density) {
+      case 'compact': {
+        style.marginTop = 0
+        style.marginBottom = 0
+        break
+      }
+      case 'cozy': {
+        style.marginTop = 16
+        style.marginBottom = 16
+        break
+      }
+      default: {
+        style.marginTop = 8
+        style.marginBottom = 8
+      }
+    }
+    return style
+  }
+
   renderPayload(payload) {
     return (
       <div style={{
@@ -24,7 +47,8 @@ export default class LogMonitorAction extends Component {
           <JSONTree theme={this.props.theme}
                     keyName={'action'}
                     data={payload}
-                    expandRoot={this.props.expandActionRoot} /> : '' }
+                    expandRoot={this.props.expandActionRoot}
+                    style={this.addDensity(styles.tree)} /> : '' }
       </div>
     );
   }


### PR DESCRIPTION
this would be an implementation to solve #1 

* for `<LogMonitor />` the default should look like:
![screen shot 2016-04-06 at 6 33 29 pm](https://cloud.githubusercontent.com/assets/5210254/14333913/6cc0fd1a-fc27-11e5-8cfe-7a8c7943cd69.png)

* for `<LogMonitor density={'cozy'} />` should look like:
![screen shot 2016-04-06 at 6 34 47 pm](https://cloud.githubusercontent.com/assets/5210254/14333958/a70fdf90-fc27-11e5-8563-33dcbdc5cb6d.png)

* for `<LogMonitor density={'compact'} />` should look like:
![screen shot 2016-04-06 at 6 48 10 pm](https://cloud.githubusercontent.com/assets/5210254/14334008/efabac0c-fc27-11e5-918e-426ed5f7f8e9.png)

* for `<LogMonitor density={'comfortable'} />` should look like:
![screen shot 2016-04-06 at 6 34 14 pm](https://cloud.githubusercontent.com/assets/5210254/14333935/84cf344e-fc27-11e5-9bd3-a018319a8a82.png)


Let me know your comments I would be happy to make fixes on this

