### PR TITLE
replace JSONTree.expandRoot with shouldExpandNode

### DIFF
--- a/src/LogMonitorEntry.js
+++ b/src/LogMonitorEntry.js
@@ -31,6 +31,7 @@ export default class LogMonitorEntry extends Component {
   constructor(props) {
     super(props);
     this.handleActionClick = this.handleActionClick.bind(this);
+    this.shouldExpandNode = this.shouldExpandNode.bind(this);
   }
 
   printState(state, error) {
@@ -47,7 +48,7 @@ export default class LogMonitorEntry extends Component {
                 this.props.select(this.props.previousState) :
                 undefined
             }
-            shouldExpandNode={() => this.props.expandStateRoot}
+            shouldExpandNode={this.shouldExpandNode}
             style={styles.tree} />
         );
       } catch (err) {
@@ -73,6 +74,10 @@ export default class LogMonitorEntry extends Component {
     if (actionId > 0) {
       onActionClick(actionId);
     }
+  }
+
+  shouldExpandNode() {
+    return this.props.expandStateRoot;
   }
 
   render() {

--- a/src/LogMonitorEntry.js
+++ b/src/LogMonitorEntry.js
@@ -47,7 +47,7 @@ export default class LogMonitorEntry extends Component {
                 this.props.select(this.props.previousState) :
                 undefined
             }
-            expandRoot={this.props.expandStateRoot}
+            shouldExpandNode={() => this.props.expandStateRoot}
             style={styles.tree} />
         );
       } catch (err) {

--- a/src/LogMonitorEntryAction.js
+++ b/src/LogMonitorEntryAction.js
@@ -14,6 +14,11 @@ const styles = {
 };
 
 export default class LogMonitorAction extends Component {
+  constructor(props) {
+    super(props);
+    this.shouldExpandNode = this.shouldExpandNode.bind(this);
+  }
+
   renderPayload(payload) {
     return (
       <div style={{
@@ -24,9 +29,13 @@ export default class LogMonitorAction extends Component {
           <JSONTree theme={this.props.theme}
                     keyPath={['action']}
                     data={payload}
-                    shouldExpandNode={() => this.props.expandActionRoot} /> : '' }
+                    shouldExpandNode={this.shouldExpandNode} /> : '' }
       </div>
     );
+  }
+
+  shouldExpandNode() {
+    return this.props.expandActionRoot;
   }
 
   render() {

--- a/src/LogMonitorEntryAction.js
+++ b/src/LogMonitorEntryAction.js
@@ -24,7 +24,7 @@ export default class LogMonitorAction extends Component {
           <JSONTree theme={this.props.theme}
                     keyPath={['action']}
                     data={payload}
-                    expandRoot={this.props.expandActionRoot} /> : '' }
+                    shouldExpandNode={() => this.props.expandActionRoot} /> : '' }
       </div>
     );
   }


### PR DESCRIPTION
react-json-tree has introduced a deprecation error https://github.com/alexkuz/react-json-tree/blob/cef50107ef66e4763c8c5abedac063d2efae303c/src/index.js#L62-L64

This PR uses the new recommended prop of shouldExpandNode