### PR TITLE
Bump react-json-tree to 0.6.6 to pull in immutable.js fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "lodash.debounce": "^4.0.4",
-    "react-json-tree": "^0.6.5",
+    "react-json-tree": "^0.6.6",
     "react-pure-render": "^1.0.2",
     "redux-devtools-themes": "^1.0.0"
   }


### PR DESCRIPTION
Bump react-json-tree to get the fix for https://github.com/alexkuz/react-json-tree/issues/45 (immutable.js support broken in redux-devtools).