### PR TITLE
Allow passing custom styles for the Button component

### DIFF
--- a/src/LogMonitorButton.js
+++ b/src/LogMonitorButton.js
@@ -66,6 +66,7 @@ export default class LogMonitorButton extends React.Component {
   render() {
     let style = {
       ...styles.base,
+      ...this.props.style,
       backgroundColor: this.props.theme.base02
     };
     if (this.props.enabled && this.state.hovered) {


### PR DESCRIPTION
We're reusing this component in `redux-devtools-extension` and `remotedev-app`, and would like to customize some styles.