### PR TITLE
Consider null types in LogMonitorEntryAction

### DIFF
--- a/src/LogMonitorEntryAction.js
+++ b/src/LogMonitorEntryAction.js
@@ -48,7 +48,7 @@ export default class LogMonitorAction extends Component {
       }}>
         <div style={styles.actionBar}
           onClick={this.props.onClick}>
-          {type.toString()}
+          {type !== null && type.toString()}
         </div>
         {!this.props.collapsed ? this.renderPayload(payload) : ''}
       </div>


### PR DESCRIPTION
I recently run into [an issue](https://github.com/zalmoxisus/redux-devtools-extension/issues/114#issuecomment-218821024) when returning an action's type as `null`, however I don't know the reason of [this change](https://github.com/gaearon/redux-devtools-log-monitor/commit/b132439121dc63c9681ff2d148999804690c7217), so maybe @anibali wants to have a look to this PR as well :)