### PR TITLE
Update react-json-tree version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "lodash.debounce": "^4.0.4",
-    "react-json-tree": "^0.7.0",
+    "react-json-tree": "^0.10.0",
     "react-pure-render": "^1.0.2",
     "redux-devtools-themes": "^1.0.0"
   }


### PR DESCRIPTION
We recently installed `redux-dev-tools` and wanted to always have the state collapsed to start as we have over 150 keys. We implemented the props as expected, and the internal code to this app seemed to be passing everything correctly to `react-json-tree`.

Our implementation of the props to collapse the tree:
```javascript
<LogMonitor
  expandActionRoot={false}
  expandStateRoot={false}
  theme="monokai"
/>
```

It always stayed expanded for some reason. I researched the version of `react-json-tree` being used and my project said it had `"react-json-tree": "^0.6.6"`.

However, the [npm registry has the latest version](https://www.npmjs.com/package/react-json-tree) of react-json-tree at version 0.10.0.

After updating to version 0.10.0, the `expandActionRoot` and `expandStateRoot` works brilliantly.

<img width="341" alt="log-monitor-collapsed" src="https://cloud.githubusercontent.com/assets/11624407/18519203/9fdd8d48-7a68-11e6-9369-95ad4898ed92.png">
