### PR TITLE
Upgrade react-json-tree to 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "lodash.debounce": "^4.0.4",
     "prop-types": "^15.0.0",
-    "react-json-tree": "^0.10.8",
+    "react-json-tree": "^0.11.0",
     "react-pure-render": "^1.0.2",
     "redux-devtools-themes": "^1.0.0"
   }


### PR DESCRIPTION
Upgrade `react-json-tree` to 0.11.0
This fixes #69 (console warnings with React 16)